### PR TITLE
Use `page.fileSlug` instead of `page.title` for slugs

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -2,3 +2,7 @@
 http://v5-chriskrycho-com.netlify.com/* https://v5.chriskrycho.com/:splat 301!
 https://v5-chriskrycho-com.netlify.com/* https://v5.chriskrycho.com/:splat 301!
 http://v5.chriskrycho.com/* https://v5.chriskrycho.com/:splat 301!
+
+# Redirect misconfigured URLs from when I accidentally had `title | slug`
+# instead of `fileSlug | slug`.
+/journal/relaunch! https://v5.chriskrycho.com/relaunch 301!

--- a/site/_redirects
+++ b/site/_redirects
@@ -5,4 +5,4 @@ http://v5.chriskrycho.com/* https://v5.chriskrycho.com/:splat 301!
 
 # Redirect misconfigured URLs from when I accidentally had `title | slug`
 # instead of `fileSlug | slug`.
-/journal/relaunch! https://v5.chriskrycho.com/relaunch 301!
+/journal/relaunch! https://v5.chriskrycho.com/journal/relaunch 301!

--- a/site/essays/essays.11tydata.json
+++ b/site/essays/essays.11tydata.json
@@ -1,4 +1,4 @@
 {
    "layout": "post.njk",
-   "permalink": "/essays/{{title | slug}}/index.html"
+   "permalink": "/essays/{{page.fileSlug | slug}}/index.html"
 }

--- a/site/journal/journal.11tydata.json
+++ b/site/journal/journal.11tydata.json
@@ -1,4 +1,4 @@
 {
    "layout": "post.njk",
-   "permalink": "/journal/{{title | slug}}/index.html"
+   "permalink": "/journal/{{page.fileSlug | slug}}/index.html"
 }

--- a/site/library/library.11tydata.json
+++ b/site/library/library.11tydata.json
@@ -1,4 +1,4 @@
 {
    "layout": "post.njk",
-   "permalink": "/library/{{title | slug}}/index.html"
+   "permalink": "/library/{{page.fileSlug | slug}}/index.html"
 }

--- a/site/pages/pages.11tydata.json
+++ b/site/pages/pages.11tydata.json
@@ -1,5 +1,5 @@
 {
    "layout": "page.njk",
    "eleventyExcludeFromCollections": true,
-   "permalink": "/{{page.fileSlug}}/index.html"
+   "permalink": "/{{page.fileSlug | slug}}/index.html"
 }

--- a/site/photography/photography.11tydata.json
+++ b/site/photography/photography.11tydata.json
@@ -1,4 +1,4 @@
 {
    "layout": "post.njk",
-   "permalink": "/photography/{{title | slug}}/index.html"
+   "permalink": "/photography/{{page.fileSlug | slug}}/index.html"
 }


### PR DESCRIPTION
Use of `page.title` for slugs throughout caused links to be generated with the wrong format, e.g. including punctuation in the `relaunch!` post slug. Add a redirect to handle that specific case as well.