### PR TITLE
Handle multiple days in archive function

### DIFF
--- a/site/_includes/components/archive-list.njk
+++ b/site/_includes/components/archive-list.njk
@@ -3,22 +3,28 @@
 {%- for year in collection %}
 <li class='year'>
    <div class='year-info'>
-      <h2 class='year-title date'>{{year.value}}</h2>
+      <h2 class='year-title date'>{{year.name}}</h2>
    </div>
    <ul class='year-items'>
-   {%- for month in year.itemsByMonth %}
+   {%- for month in year.months %}
       <li class='month'>
          <h3 class='month-title date'>{{month.name}}</h3>
          <ul class='month-items'>
-         {%- for item in month.items %}
-            <li class='item'>
-               <h4 class='item-date date'>{% localeDate item.date, 'dd' %}</h4>
-               <h5 class='item-title'>
-                  <a href='{{item.url}}' class='item-permalink'>
-                     {{item.data.title | safe}}
-                  </a>
-               </h5>
-               <p class='item-subtitle'>{{item.data.subtitle | safe}}</h2>
+         {%- for day in month.days %}
+            <li class='day'>
+               <h4 class='day-title date'>{{day.name}}</h4>
+               <ul class='day-items'>
+               {%- for item in day.items %}
+                  <li class='item'>
+                     <h5 class='item-title'>
+                        <a href='{{item.url}}' class='item-permalink'>
+                           {{item.data.title | safe}}
+                        </a>
+                     </h5>
+                     <p class='item-subtitle'>{{item.data.subtitle | safe}}</h2>
+                  </li>
+               {% endfor -%}
+               </ul>
             </li>
          {% endfor -%}
          </ul>

--- a/site/_includes/styles/components/_archive-list.scss
+++ b/site/_includes/styles/components/_archive-list.scss
@@ -81,14 +81,24 @@
       grid-area: entries;
    }
 
-   .item {
+   .day {
       display: grid;
-      grid-template: 
-         "day title   "
-         " .  subtitle" auto / 1em auto;
+      grid-template: "day entries" auto / 1em auto;
       grid-gap: 0 1rem;
       gap: 0 1rem;
-      // max-width: 36rem;
+      margin: 0 0 ms(1);
+      width: 100%;
+   }
+
+   .day-title {
+      grid-area: day;
+   }
+
+   .day-items {
+      grid-area: entries;
+   }
+
+   .item {
       margin: 0 0 ms(1);
       width: 100%;
    }
@@ -98,17 +108,12 @@
    }
 
    .item-title {
-      grid-area: title;
       font: {
          family: var(--sans-subhead);
          size: calc(var(--sans-adjust) * #{ms(0)});
          weight: 400;
       }
       margin-bottom: ms(-8);
-   }
-
-   .item-date {
-      grid-area: day;
    }
 
    .item-permalink {
@@ -127,7 +132,6 @@
    }
 
    .item-subtitle {
-      grid-area: subtitle;
       line-height: 1.1;
       font-size: ms(-1);
       font-style: italic;
@@ -155,7 +159,7 @@
          width: 3rem;
       }
 
-      .item {
+      .day {
          grid-gap: 0 0.5rem;
          gap: 0 0.5rem;
       }   


### PR DESCRIPTION
- Rework the data structures to correctly account for the possibility of multiple items for a single day.
- Extract individual functions for each layer of conversion from maps to final output structure, so each layer is small and clear.
- Set the name in a tuple for each layer of the year/month/day maps.
- Update the invocations in the archive-list template to match the new names in the nested `Archive` data type (now more consistent), and to create another layer of list hierarchy within the archive: for days, within which live items.
- Update the styles for the archive list so the grid displays correctly given the new structure.

Resolves #76.