### PR TITLE
Fix typo in stateful/class-backed example

### DIFF
--- a/site/journal/Ember Template Imports/Part 1.md
+++ b/site/journal/Ember Template Imports/Part 1.md
@@ -170,7 +170,7 @@ This example introduces a stateful, class-backed component which uses a bound fu
         {{on "input" this.updateName}}
       />
 
-      <button type='submit' disabled={{eq this.value.length 0}}>
+      <button type='submit' disabled={{eq this.name.length 0}}>
         Generate
       </button>
     </form>


### PR DESCRIPTION
I'm pretty sure that `this.value` is a typo, the only value in that example is the one that gets extracted from the `input` event `event.target.value` and I doubt it has anything to do with the button.