### PR TITLE
Fix code typo related to `this.hasBeenClicked`

### DIFF
--- a/site/journal/2022/Conditional Modifiers and Helpers in Emberjs.md
+++ b/site/journal/2022/Conditional Modifiers and Helpers in Emberjs.md
@@ -87,7 +87,7 @@ export default class Item extends Component {
   @tracked hasBeenClicked = false;
 
   get trackInteraction() {
-    return this.!this.hasBeenClicked ? TrackInteraction : null;
+    return !this.hasBeenClicked ? TrackInteraction : null;
   }
 
   markAsClicked = () => {


### PR DESCRIPTION
There was an extra `this.` in the code. Removed it.