### PR TITLE
Point to `canon` branch instead of non-existent `main` branch

### DIFF
--- a/eleventy/page-links.ts
+++ b/eleventy/page-links.ts
@@ -6,12 +6,12 @@ const renderable = (path: string) => encodeURIComponent(corrected(path));
 
 /** Link to the history of the file on GitHub */
 export const history = (path: string): string =>
-   `${SiteConfig.repo}/commits/main/${renderable(path)}`;
+   `${SiteConfig.repo}/commits/canon/${renderable(path)}`;
 
 /** Link to edit the file on GitHub */
 export const edit = (inputPath: string): string =>
-   `${SiteConfig.repo}/edit/main/${renderable(inputPath)}`;
+   `${SiteConfig.repo}/edit/canon/${renderable(inputPath)}`;
 
 /** Link to view the file on GitHub */
 export const source = (inputPath: string): string =>
-   `${SiteConfig.repo}/blob/main/${renderable(inputPath)}`;
+   `${SiteConfig.repo}/blob/canon/${renderable(inputPath)}`;


### PR DESCRIPTION
I tried to follow the "Submit a correction!" link at the bottom of [An Ice Cold Take on CI Config Systems ](https://v5.chriskrycho.com/notes/an-ice-cold-take-on-ci-config-systems/).
That link gives a HTTP 404 result because there is no `main` branch (anymore?)

(the original issue I saw seems to be fixed already)

